### PR TITLE
[2023/08/22] Feat/vote/result >> 투표 후 대기 및 이후 화면 연결

### DIFF
--- a/Ourtine/Ourtine.xcodeproj/project.pbxproj
+++ b/Ourtine/Ourtine.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		88FE2D3A2A7ED4AD00C475A7 /* HC_Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88FE2D392A7ED4AD00C475A7 /* HC_Category.swift */; };
 		B61D6AB52A9303020002295B /* OthersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61D6AB42A9303020002295B /* OthersViewController.swift */; };
 		B61D6AB72A930CB70002295B /* VoteMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61D6AB62A930CB70002295B /* VoteMemberViewController.swift */; };
+		B61D6AB92A93A80B0002295B /* WaitAfterVoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61D6AB82A93A80B0002295B /* WaitAfterVoteViewController.swift */; };
 		B6394E932A86A2F30040B8FF /* CamerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6394E922A86A2F30040B8FF /* CamerManager.swift */; };
 		B63C63B02A7B4ACB00AF09CA /* LetterSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63C63AF2A7B4ACB00AF09CA /* LetterSpacing.swift */; };
 		B63C63B22A7B5C0F00AF09CA /* FigmaShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63C63B12A7B5C0E00AF09CA /* FigmaShadow.swift */; };
@@ -263,6 +264,7 @@
 		88FE2D392A7ED4AD00C475A7 /* HC_Category.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HC_Category.swift; sourceTree = "<group>"; usesTabs = 0; };
 		B61D6AB42A9303020002295B /* OthersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OthersViewController.swift; sourceTree = "<group>"; };
 		B61D6AB62A930CB70002295B /* VoteMemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoteMemberViewController.swift; sourceTree = "<group>"; };
+		B61D6AB82A93A80B0002295B /* WaitAfterVoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitAfterVoteViewController.swift; sourceTree = "<group>"; };
 		B6394E922A86A2F30040B8FF /* CamerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CamerManager.swift; sourceTree = "<group>"; };
 		B63C63AF2A7B4ACB00AF09CA /* LetterSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterSpacing.swift; sourceTree = "<group>"; };
 		B63C63B12A7B5C0E00AF09CA /* FigmaShadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaShadow.swift; sourceTree = "<group>"; };
@@ -390,6 +392,7 @@
 				8851EE3A2A8CC4CB0062D3E4 /* PrimaryViewController.swift */,
 				B61D6AB42A9303020002295B /* OthersViewController.swift */,
 				B61D6AB62A930CB70002295B /* VoteMemberViewController.swift */,
+				B61D6AB82A93A80B0002295B /* WaitAfterVoteViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -759,6 +762,7 @@
 				88BDD32E2A82C3760082A961 /* HC_finalView.swift in Sources */,
 				B6BEB5942A892B9800A311B8 /* ReviewViewController.swift in Sources */,
 				88BDD3262A82B3180082A961 /* HC_selectFriendsViewController.swift in Sources */,
+				B61D6AB92A93A80B0002295B /* WaitAfterVoteViewController.swift in Sources */,
 				88E653972A80151A00ABF9D9 /* HC_memberCountView.swift in Sources */,
 				8851EE322A8C22E30062D3E4 /* FollowAPI sending Struct.swift in Sources */,
 				8851EE2B2A8C22E30062D3E4 /* UserAPI.swift in Sources */,

--- a/Ourtine/Ourtine.xcodeproj/project.pbxproj
+++ b/Ourtine/Ourtine.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		B61D6AB52A9303020002295B /* OthersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61D6AB42A9303020002295B /* OthersViewController.swift */; };
 		B61D6AB72A930CB70002295B /* VoteMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61D6AB62A930CB70002295B /* VoteMemberViewController.swift */; };
 		B61D6AB92A93A80B0002295B /* WaitAfterVoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61D6AB82A93A80B0002295B /* WaitAfterVoteViewController.swift */; };
+		B61D6ABB2A93BC550002295B /* ShowWinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61D6ABA2A93BC550002295B /* ShowWinnerViewController.swift */; };
 		B6394E932A86A2F30040B8FF /* CamerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6394E922A86A2F30040B8FF /* CamerManager.swift */; };
 		B63C63B02A7B4ACB00AF09CA /* LetterSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63C63AF2A7B4ACB00AF09CA /* LetterSpacing.swift */; };
 		B63C63B22A7B5C0F00AF09CA /* FigmaShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63C63B12A7B5C0E00AF09CA /* FigmaShadow.swift */; };
@@ -265,6 +266,7 @@
 		B61D6AB42A9303020002295B /* OthersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OthersViewController.swift; sourceTree = "<group>"; };
 		B61D6AB62A930CB70002295B /* VoteMemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoteMemberViewController.swift; sourceTree = "<group>"; };
 		B61D6AB82A93A80B0002295B /* WaitAfterVoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitAfterVoteViewController.swift; sourceTree = "<group>"; };
+		B61D6ABA2A93BC550002295B /* ShowWinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowWinnerViewController.swift; sourceTree = "<group>"; };
 		B6394E922A86A2F30040B8FF /* CamerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CamerManager.swift; sourceTree = "<group>"; };
 		B63C63AF2A7B4ACB00AF09CA /* LetterSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterSpacing.swift; sourceTree = "<group>"; };
 		B63C63B12A7B5C0E00AF09CA /* FigmaShadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaShadow.swift; sourceTree = "<group>"; };
@@ -393,6 +395,7 @@
 				B61D6AB42A9303020002295B /* OthersViewController.swift */,
 				B61D6AB62A930CB70002295B /* VoteMemberViewController.swift */,
 				B61D6AB82A93A80B0002295B /* WaitAfterVoteViewController.swift */,
+				B61D6ABA2A93BC550002295B /* ShowWinnerViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -759,6 +762,7 @@
 				8851EE222A8C22E30062D3E4 /* myUserInfo.swift in Sources */,
 				882B757E2A862A6A000B3943 /* UIImage + CircularCrop.swift in Sources */,
 				88FE2D352A7ED46600C475A7 /* HC_introduceViewController.swift in Sources */,
+				B61D6ABB2A93BC550002295B /* ShowWinnerViewController.swift in Sources */,
 				88BDD32E2A82C3760082A961 /* HC_finalView.swift in Sources */,
 				B6BEB5942A892B9800A311B8 /* ReviewViewController.swift in Sources */,
 				88BDD3262A82B3180082A961 /* HC_selectFriendsViewController.swift in Sources */,

--- a/Ourtine/Ourtine/SceneDelegate.swift
+++ b/Ourtine/Ourtine/SceneDelegate.swift
@@ -24,7 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         
         // 첫 viewController 설정
-        let viewController = PrimaryViewController()
+        let viewController = VoteMemberViewController()
         
         // navigationController 사용시
         //let navigationController = UINavigationController(rootViewController: viewController)

--- a/Ourtine/Ourtine/ViewController/ShowWinnerViewController.swift
+++ b/Ourtine/Ourtine/ViewController/ShowWinnerViewController.swift
@@ -1,0 +1,149 @@
+//
+//  ShowWinnerViewController.swift
+//  Ourtine
+//
+//  Created by eunji on 2023/08/22.
+//
+
+import UIKit
+import SnapKit
+
+class ShowWinnerViewController: UIViewController {
+    
+    private var tempUserName: String = "성식"
+    private var winnerNames: [String] = []
+
+    private let blurEffectView: UIVisualEffectView = {
+        let blurEffect = UIBlurEffect(style: .dark)
+        let view = UIVisualEffectView(effect: blurEffect)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let mainPhrase: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .app_SecondaryColor
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 28, weight: .semibold)
+        label.text = "오늘의 습관러는"
+        return label
+    }()
+    
+    private let winnersLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .white
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 22, weight: .semibold)
+        label.text = ""
+        return label
+    }()
+    
+    private let winnerImage: UserProfileImageView = {
+        let view = UserProfileImageView(frame: CGRect(x: 0, y: 0, width: 299.03, height: 299.03))
+        view.contentMode = .scaleAspectFill
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.borderWidth = 2
+        view.layer.borderColor = UIColor.white.cgColor
+        return view
+    }()
+    
+    private let encouragePhrase: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 24, weight: .bold)
+        label.text = ""
+        return label
+    }()
+
+    override func viewDidLoad() {
+        view.backgroundColor = .black.withAlphaComponent(0.6)
+        super.viewDidLoad()
+
+        [
+            blurEffectView,
+            mainPhrase,
+            winnersLabel,
+            winnerImage,
+            encouragePhrase
+        ].forEach{view.addSubview($0)}
+        
+        setUI()
+    }
+    
+    private func setUI() {
+        updateWinners()
+        updateEncouragePhrase()
+        setConstraints()
+    }
+
+    private func updateWinners() {
+        // TODO: Get winner name by API
+        var combinedString = ""
+        let winnerName1 = "A"
+        winnerNames.append(winnerName1)
+        for (index, name) in winnerNames.enumerated() {
+            if index == 0 {
+                combinedString += "\(name)님"
+            } else {
+                combinedString += ", \(name)님"
+            }
+        }
+        
+        winnersLabel.text = combinedString
+    }
+    
+    private func updateEncouragePhrase() {
+        let changeText = "베스트 습관러"
+
+        if (winnerNames.contains(tempUserName)) {
+            let text = "\(tempUserName)님,\n베스트 습관러로 선정된 것을\n축하드립니다!"
+            encouragePhrase.halfTextColorChange(fullText: text, changeText: changeText, color: .app_SecondaryColor)
+        } else {
+            let text = "\(tempUserName)님, 다음에는\n베스트 습관러가 되어보아요!"
+            encouragePhrase.halfTextColorChange(fullText: text, changeText: changeText, color: .app_SecondaryColor)        }
+    }
+    
+    private func setConstraints() {
+        blurEffectView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        mainPhrase.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(112)
+            make.centerX.equalToSuperview()
+        }
+        
+        winnersLabel.snp.makeConstraints { make in
+            make.top.equalTo(mainPhrase.snp.bottom).offset(22)
+            make.centerX.equalToSuperview()
+        }
+        
+        winnerImage.snp.makeConstraints { make in
+            make.top.equalTo(mainPhrase.snp.bottom).offset(126.48)
+            make.centerX.equalToSuperview()
+            make.width.height.equalTo(299.03)
+        }
+        
+        encouragePhrase.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().offset(-129.59)
+            make.centerX.equalToSuperview()
+        }
+        
+    }
+}
+
+import SwiftUI
+
+struct ShowWinnerViewController_Preview: PreviewProvider {
+    static var previews: some View {
+        UIViewControllerPreview {
+            let ViewController = ShowWinnerViewController()
+            return ViewController
+        }
+    }
+}

--- a/Ourtine/Ourtine/ViewController/ShowWinnerViewController.swift
+++ b/Ourtine/Ourtine/ViewController/ShowWinnerViewController.swift
@@ -79,6 +79,7 @@ class ShowWinnerViewController: UIViewController {
         updateWinners()
         updateEncouragePhrase()
         setConstraints()
+        updateView()
     }
 
     private func updateWinners() {
@@ -133,7 +134,6 @@ class ShowWinnerViewController: UIViewController {
             make.bottom.equalToSuperview().offset(-129.59)
             make.centerX.equalToSuperview()
         }
-        
     }
 }
 

--- a/Ourtine/Ourtine/ViewController/VoteMemberViewController.swift
+++ b/Ourtine/Ourtine/ViewController/VoteMemberViewController.swift
@@ -259,6 +259,10 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
             voteResultVC.modalPresentationStyle = .overCurrentContext
             self.present(voteResultVC, animated: true)
             
+            dismiss(animated: false) {
+                let newVC = ReviewViewController()
+                self.navigationController?.pushViewController(newVC, animated: false)
+            }
         }
     }
 

--- a/Ourtine/Ourtine/ViewController/VoteMemberViewController.swift
+++ b/Ourtine/Ourtine/ViewController/VoteMemberViewController.swift
@@ -10,6 +10,8 @@ import SnapKit
 
 class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionViewDelegate {
     
+    private var hasPresentedBefore: Bool = false
+    
     private var isVoteBtnTapped: Bool = false
     
     weak var delegate: ParticipatingMemberCollectionViewDelegate?
@@ -118,13 +120,14 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
     @objc private func voteBtnTapped() {
         // TODO: selectedMemberData API로 전송
         // TODO: 투표 종료 시간 되면 화면 이동.
-//        let vc = ReviewViewController()
-//        navigationController?.pushViewController(vc, animated: false)
         isVoteBtnTapped = true
         let vc = WaitAfterVoteViewController()
         vc.didVoted = isSelectionMade
-        vc.modalPresentationStyle = .overCurrentContext
-        present(vc, animated: true)
+        if (!hasPresentedBefore) {
+            vc.modalPresentationStyle = .overCurrentContext
+            present(vc, animated: true)
+            hasPresentedBefore = true
+        }
     }
 
     override func viewDidLoad() {
@@ -242,8 +245,21 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
     private func presentModal() {
         let vc = WaitAfterVoteViewController()
         vc.didVoted = isVoteBtnTapped ? isSelectionMade : false
-        vc.modalPresentationStyle = .overCurrentContext
-        present(vc, animated: true)
+        
+        if !hasPresentedBefore {
+            vc.modalPresentationStyle = .overCurrentContext
+            self.present(vc, animated: true)
+            hasPresentedBefore = true
+        }
+        
+        dismiss(animated: true) { [weak self] in
+            guard let self = self else {return}
+            
+            let voteResultVC = ShowWinnerViewController()
+            voteResultVC.modalPresentationStyle = .overCurrentContext
+            self.present(voteResultVC, animated: true)
+            
+        }
     }
 
 }

--- a/Ourtine/Ourtine/ViewController/VoteMemberViewController.swift
+++ b/Ourtine/Ourtine/ViewController/VoteMemberViewController.swift
@@ -29,8 +29,6 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
         
         let selectedUserIds = selectedMemberData.map {$0.userId}
         print("\(selectedUserIds)")
-        
-//        selectedCellCount = collectionView.selectedMemberData.count
         print(selectedCellCount)
         isSelectionMade = selectedCellCount > 0
     }
@@ -118,11 +116,16 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
     @objc private func voteBtnTapped() {
         // TODO: selectedMemberData API로 전송
         // TODO: 투표 종료 시간 되면 화면 이동.
-        let vc = ReviewViewController()
-        navigationController?.pushViewController(vc, animated: false)
+//        let vc = ReviewViewController()
+//        navigationController?.pushViewController(vc, animated: false)
+        let vc = WaitAfterVoteViewController()
+        vc.didVoted = isSelectionMade
+        vc.modalPresentationStyle = .overCurrentContext
+        present(vc, animated: true)
     }
 
     override func viewDidLoad() {
+        view.backgroundColor = .white
         super.viewDidLoad()
         
         [
@@ -186,6 +189,8 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
         // voteBtn
         voteBtn.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
+            make.trailing.equalTo(-31)
+            make.leading.equalTo(31)
             make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-32)
         }
     }

--- a/Ourtine/Ourtine/ViewController/VoteMemberViewController.swift
+++ b/Ourtine/Ourtine/ViewController/VoteMemberViewController.swift
@@ -10,6 +10,8 @@ import SnapKit
 
 class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionViewDelegate {
     
+    private var isVoteBtnTapped: Bool = false
+    
     weak var delegate: ParticipatingMemberCollectionViewDelegate?
     
     var selectedMemberData: [MemberModel] = []
@@ -118,6 +120,7 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
         // TODO: 투표 종료 시간 되면 화면 이동.
 //        let vc = ReviewViewController()
 //        navigationController?.pushViewController(vc, animated: false)
+        isVoteBtnTapped = true
         let vc = WaitAfterVoteViewController()
         vc.didVoted = isSelectionMade
         vc.modalPresentationStyle = .overCurrentContext
@@ -140,11 +143,13 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
         setupUI()
         setConstraints()
         collectionView.delegate = self
+        startCountDown()
     }
     
 
     private func setupUI() {
         // TODO: Get Left Second
+        
         leftSecondLabel.text = "23"
         
         voteBtn.addTarget(self, action: #selector(voteBtnTapped), for: .touchUpInside)
@@ -217,6 +222,28 @@ class VoteMemberViewController: UIViewController, ParticipatingMemberCollectionV
             let titleAttr = NSAttributedString(string: "베스터 습관러 투표하러 가기", attributes: attributes)
             voteBtn.setAttributedTitle(titleAttr, for: .normal)
         }
+    }
+    
+    private func startCountDown() {
+        var leftTime = 5
+        Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            leftTime -= 1
+            
+            if leftTime > 0 {
+                self.leftSecondLabel.text = String(leftTime)
+            } else {
+                timer.invalidate()
+                self.presentModal()
+                self.leftSecondLabel.text = ""
+            }
+        }
+    }
+    
+    private func presentModal() {
+        let vc = WaitAfterVoteViewController()
+        vc.didVoted = isVoteBtnTapped ? isSelectionMade : false
+        vc.modalPresentationStyle = .overCurrentContext
+        present(vc, animated: true)
     }
 
 }

--- a/Ourtine/Ourtine/ViewController/WaitAfterVoteViewController.swift
+++ b/Ourtine/Ourtine/ViewController/WaitAfterVoteViewController.swift
@@ -36,20 +36,33 @@ class WaitAfterVoteViewController: UIViewController {
         label.textColor = .white
         return label
     }()
+    
+    private let blurEffectView: UIVisualEffectView = {
+        let blurEffect = UIBlurEffect(style: .dark)
+        let view = UIVisualEffectView(effect: blurEffect)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
 
     override func viewDidLoad() {
-        view.backgroundColor = .black.withAlphaComponent(0.6)
         super.viewDidLoad()
         
         setUI()
     }
     
     private func setUI() {
+        view.backgroundColor = .clear
+        updateBackground()
+        
         if didVoted {
             voted()
         } else {
             unVoted()
         }
+        
+        updateView()
+        
+        
     }
     
     private func unVoted() {
@@ -78,5 +91,31 @@ class WaitAfterVoteViewController: UIViewController {
         }
     }
     
+    private func updateView() {
+        // TODO: move to other view.
+        // TODO: if 현재시간 > 종료 예정 시간
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            self.dismiss(animated: false)
+        }
+    }
+    
+    private func updateBackground() {
+        view.addSubview(blurEffectView)
+        blurEffectView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
 
+}
+
+import SwiftUI
+
+struct WaitAfterVoteViewController_Preview: PreviewProvider {
+    static var previews: some View {
+        UIViewControllerPreview {
+            let ViewController = WaitAfterVoteViewController()
+            return ViewController
+        }
+    }
 }

--- a/Ourtine/Ourtine/ViewController/WaitAfterVoteViewController.swift
+++ b/Ourtine/Ourtine/ViewController/WaitAfterVoteViewController.swift
@@ -1,0 +1,82 @@
+//
+//  WaitAfterVoteViewController.swift
+//  Ourtine
+//
+//  Created by eunji on 2023/08/21.
+//
+
+import UIKit
+import SnapKit
+
+class WaitAfterVoteViewController: UIViewController {
+    
+    var didVoted: Bool = false
+    
+    private var unVotedTextOne: UILabel = {
+        let label = UILabel()
+        label.text = "앗"
+        label.textAlignment = .center
+        label.textColor = .app_SecondaryColor
+        label.font = .systemFont(ofSize: 34, weight: .semibold)
+        return label
+    }()
+    
+    private var unVotedTextTwo: UILabel = {
+        let label = UILabel()
+        label.text = "투표시간이 지났어요!"
+        label.font = .systemFont(ofSize: 24, weight: .semibold)
+        label.textColor = .white
+        return label
+    }()
+    
+    private var votedText: UILabel = {
+        let label = UILabel()
+        label.text = "투표하는 중이에요!"
+        label.font = .systemFont(ofSize: 28, weight: .semibold)
+        label.textColor = .white
+        return label
+    }()
+
+    override func viewDidLoad() {
+        view.backgroundColor = .black.withAlphaComponent(0.6)
+        super.viewDidLoad()
+        
+        setUI()
+    }
+    
+    private func setUI() {
+        if didVoted {
+            voted()
+        } else {
+            unVoted()
+        }
+    }
+    
+    private func unVoted() {
+        [
+            unVotedTextOne,
+            unVotedTextTwo
+        ].forEach { view.addSubview($0) }
+        
+        unVotedTextOne.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(291.5)
+            make.centerX.equalToSuperview()
+        }
+        
+        unVotedTextTwo.snp.makeConstraints { make in
+            make.top.equalTo(unVotedTextOne).offset(57)
+            make.centerX.equalToSuperview()
+        }
+    }
+    
+    private func voted() {
+        view.addSubview(votedText)
+        
+        votedText.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(388.06)
+            make.centerX.equalToSuperview()
+        }
+    }
+    
+
+}

--- a/Ourtine/Ourtine/ViewController/WaitingViewController.swift
+++ b/Ourtine/Ourtine/ViewController/WaitingViewController.swift
@@ -91,7 +91,6 @@ class WaitingViewController: UIViewController {
     // 카운트다운 완료시 화면 전환 함수
     @objc func updateView() {
         let vc = ParticipatingViewController()
-//        let vc = ReviewViewController()
         navigationController?.pushViewController(vc, animated: false)
     }
 


### PR DESCRIPTION
## 작업사항
- WaitAfterVoteViewController: 사용자의 투표 여부에 따라 투표 이후에 보여줄 화면 생성
: 해당 뷰는 뒤에가 투명한 화면으로, Navigation이 아닌 present를 사용하였고, 이후 화면에서 navigation을 사용할 수 있도록 화면을 보여준 후 dismiss 하는 형식으로 구현하였습니다.
- ShowWinnerViewController: 베스트 습관러로 뽑힌 사람을 보여주는 화면 생성
: 상단의 뷰와 동일하여 present 방식을 사용한 후, dismiss하여 구현.
- VoteMemberViewController - WaitAfterVoteViewController - ShowWinnerViewController 연결
: VoteMemberViewController를 제외하고서는 present로 구현되어 있어, VoteMemberView에서 WaitAfterVoteView를 present로 보여준 후 dismiss하여 다시 VoteMemberView로 돌아온 후, ShowWinnerView를 present으로 보여준 후 dismiss 하여 또 다시 VoteMemberVIew로 돌아왔습니다. 그 후, ReviewView와 push를 통해 연결하였습니다.

## 이슈번호
close #53 
close #54 

## 특이사항
X